### PR TITLE
Mobile gyro disable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,6 @@ export default function App(): JSX.Element {
         <Camera
           position={{ x: 0, y: 0.8, z: 0 }}
           occupants
-          magicWindowTrackingEnabled={false}
         >
           <Cylinder
             ammo-body="type: kinematic; emitCollisionEvents: true;"

--- a/src/aframe/joystick.js
+++ b/src/aframe/joystick.js
@@ -18,6 +18,8 @@ if (isMobileDevice) {
       const { camera } = document.querySelector('a-scene');
       this.camera = camera;
 
+      camera.el.setAttribute('magic-window-tracking-enabled', 'false');
+
       const manager = nipplejs.create({
         mode: 'static',
         zone: joystick,


### PR DESCRIPTION
# Doing

- 모바일 디바이스에서 joystick 활성화 할 때 카메라에 magic-window-tracking-enabled = false 설정하도록 함

# Why

![image](https://user-images.githubusercontent.com/41536271/177509232-dcad0ee8-af6d-4ee4-a438-eb6e9432c5bb.png)

왠지 제대로 안들어가서 직접 넣으려 함