### PR TITLE
Mobile gyro disable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import './aframe/look-controls-touch-y-axis';
 import './aframe/joystick';
 
 const socket = io(import.meta.env.VITE_API_URL);
+const isMobileDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
 AFRAME.registerComponent('click-open-modal', {
   init() {
@@ -100,6 +101,9 @@ export default function App(): JSX.Element {
         <Camera
           position={{ x: 0, y: 0.8, z: 0 }}
           occupants
+          lookControls={{
+            magicWindowTrackingEnabled: !isMobileDevice,
+          }}
         >
           <Cylinder
             ammo-body="type: kinematic; emitCollisionEvents: true;"

--- a/src/aframe/joystick.js
+++ b/src/aframe/joystick.js
@@ -18,8 +18,6 @@ if (isMobileDevice) {
       const { camera } = document.querySelector('a-scene');
       this.camera = camera;
 
-      camera.el.setAttribute('magic-window-tracking-enabled', 'false');
-
       const manager = nipplejs.create({
         mode: 'static',
         zone: joystick,


### PR DESCRIPTION
# Doing

- 모바일 디바이스일 때 camera의 lookControls.magicWindowTrackingEnabled 를 disabled 시킴

# Why

찾아보니 magicWindowTrackingEnabled이 lookControls의 옵션이었음